### PR TITLE
Changed Front Controller

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -8,47 +8,51 @@ if (extension_loaded('newrelic')) {
     newrelic_set_appname('Olytics');
 }
 
-$loader = require_once __DIR__.'/../app/bootstrap.php.cache';
+// Get the environment from Apache
+$env = strtolower(getenv('APP_ENV'));
 
-// Use APC for autoloading to improve performance.
-// Change 'sf2' to a unique prefix in order to prevent cache key conflicts
-// with other applications also using APC.
-/*
-$apcLoader = new ApcClassLoader('sf2', $loader);
-$loader->unregister();
-$apcLoader->register(true);
-*/
+// Determine the loader. All non-dev environments should use the bootstrap cache class
+$loader = ($env !== 'dev') ? require_once __DIR__.'/../app/bootstrap.php.cache' : require_once __DIR__.'/../app/autoload.php';
 
+// Load APC for improved autoloading performance based on server enviroment varible 'USE_APC'
+if (getenv('USE_APC') === 'true') {
+    // Uses the platform Kernel app name as a prefix in order to prevent cache key conflicts
+    $apcLoader = new ApcClassLoader('cygnus_olytics_v1', $loader);
+    $loader->unregister();
+    $apcLoader->register(true);
+}
+
+// Create the request
 $request = Request::createFromGlobals();
 Request::setTrustedProxies(array('192.168.0.1/22'));
 
-$parts = explode('.', $request->server->get('SERVER_NAME'));
-
-$env = 'prod';
-
-if (in_array('dev', $parts)) {
-    $env = 'dev';
+// Allow debug mode to be enabled independantly of environment.
+$debug = false;
+if ($request->cookies->has('debug') || 'dev' === $env) {
+    $debug = true;
+    Debug::enable();
 }
 
 require_once __DIR__.'/../app/AppKernel.php';
-//require_once __DIR__.'/../app/AppCache.php';
 
-switch ($env) {
-    case 'dev':
-        Debug::enable();
-        $kernel = new AppKernel('dev', true);
-        break;
-
-    default:
-        $kernel = new AppKernel('prod', false);
-        break;
+// Load environment based on server environment variable 'APP_ENV'
+if ('prod' === $env) {
+    $kernel = new AppKernel('prod', $debug);
+    $kernel->loadClassCache();
+} elseif ('dev' === $env) {
+    $kernel = new AppKernel('dev', $debug);
+} else {
+    $kernel = new AppKernel('test', $debug);
+    $kernel->loadClassCache();
 }
 
-$kernel->loadClassCache();
-//$kernel = new AppCache($kernel);
-
-// When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter
-//Request::enableHttpMethodParameterOverride();
+// Load AppCache based on server environment variable 'APP_CACHE'
+if (getenv('USE_CACHE') === 'true') {
+    require_once __DIR__.'/../app/AppCache.php';
+    $kernel = new AppCache($kernel);
+    // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter
+    Request::enableHttpMethodParameterOverride();
+}
 
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
- Added support for APC and Cache classing
- Changed environment detection to use Environment Variables
- Setup enabling/disabling of caching based on Environment Variables

**Please Note** The production and development Apache configuration will need to change to reflect these settings.
#### Development Apache Virtual Host Settings

SetEnv APP_ENV dev
SetEnv USE_CACHE false
SetEnv USE_APC true
#### Production Apache Virtual Host Settings

SetEnv APP_ENV prod
SetEnv USE_CACHE true
SetEnv USE_APC true
