### PR TITLE
Added support for pre-persist Event hooks

### DIFF
--- a/src/Cygnus/OlyticsBundle/CygnusOlyticsBundle.php
+++ b/src/Cygnus/OlyticsBundle/CygnusOlyticsBundle.php
@@ -5,6 +5,7 @@ namespace Cygnus\OlyticsBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Cygnus\OlyticsBundle\DependencyInjection\Compiler\AggregationCompilerPass;
+use Cygnus\OlyticsBundle\DependencyInjection\Compiler\EventHookCompilerPass;
 
 class CygnusOlyticsBundle extends Bundle
 {
@@ -14,5 +15,8 @@ class CygnusOlyticsBundle extends Bundle
 
         // Register aggregations
         $container->addCompilerPass(new AggregationCompilerPass());
+
+        // Register event hooks
+        $container->addCompilerPass(new EventHookCompilerPass());
     }
 }

--- a/src/Cygnus/OlyticsBundle/DependencyInjection/Compiler/EventHookCompilerPass.php
+++ b/src/Cygnus/OlyticsBundle/DependencyInjection/Compiler/EventHookCompilerPass.php
@@ -1,0 +1,39 @@
+<?php
+namespace Cygnus\OlyticsBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class EventHookCompilerPass implements CompilerPassInterface
+{
+    /**
+     * Adds tagged event hooks to the event hook manager service
+     *
+     * @param   Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @return  void
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $managerId = 'cygnus_olytics.event_hook_manager';
+        if (!$container->hasDefinition($managerId)) {
+            return;
+        }
+
+        // Get the event hook manager service definition
+        $definition = $container->getDefinition($managerId);
+
+        // Get the tagged event hook services
+        $resources = $container->findTaggedServiceIds('cygnus_olytics.event_hook');
+
+        foreach ($resources as $id => $tagAttributes) {
+            foreach ($tagAttributes as $attributes) {
+                // Add the aggregation to the manager service definition
+                $definition->addMethodCall(
+                    'addEventHook',
+                    [new Reference($id)]
+                );
+            }
+        }
+    }
+}

--- a/src/Cygnus/OlyticsBundle/Event/Persistor.php
+++ b/src/Cygnus/OlyticsBundle/Event/Persistor.php
@@ -2,6 +2,7 @@
 namespace Cygnus\OlyticsBundle\Event;
 
 use Cygnus\OlyticsBundle\Aggregation\Manager as AggregationManager;
+use Cygnus\OlyticsBundle\EventHook\Manager as EventHookManager;
 use Cygnus\OlyticsBundle\Index\IndexManager;
 use Cygnus\OlyticsBundle\Model\Event\EventInterface;
 use Doctrine\MongoDB\Connection;
@@ -16,17 +17,25 @@ abstract class Persistor implements PersistorInterface
 
     protected $am;
 
-    public function __construct(Connection $connection, IndexManager $indexManager, AggregationManager $am, array $accounts)
+    protected $hm;
+
+    public function __construct(Connection $connection, IndexManager $indexManager, AggregationManager $am, EventHookManager $hm, array $accounts)
     {
         $this->connection = $connection;
         $this->indexManager = $indexManager;
         $this->accounts = $accounts;
         $this->am = $am;
+        $this->hm = $hm;
     }
 
     public function getAggregationManager()
     {
         return $this->am;
+    }
+
+    public function getEventHookManager()
+    {
+        return $this->hm;
     }
 
     public function getConnection()

--- a/src/Cygnus/OlyticsBundle/Event/Website/WebsitePersistor.php
+++ b/src/Cygnus/OlyticsBundle/Event/Website/WebsitePersistor.php
@@ -85,12 +85,15 @@ class WebsitePersistor extends Persistor
     /**
      * Persists the Event to the database
      *
-     * @todo   This should dispatch an event once completed that the aggregations can hook into. For now just run manually.
+     * @todo   This should dispatch an event once completed that the aggregations and event modification hooks can listen for. For now just run manually.
      * @param  WebsiteEvent   $event
      * @return void
      */
     protected function persistEvent(WebsiteEvent $event)
     {
+        // Execute event modification hooks
+        $event = $this->getEventHookManager()->executeAll($event, $this->account, $this->product);
+
         $indexes = $this->getIndexManager()->indexFactoryMulti($this->getEventIndexes());
         $this->getIndexManager()->createIndexes($indexes, $this->getDatabaseName(), $this->getEventCollection($event->getEntity()));
 

--- a/src/Cygnus/OlyticsBundle/EventHook/HookInterface.php
+++ b/src/Cygnus/OlyticsBundle/EventHook/HookInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Cygnus\OlyticsBundle\EventHook;
+
+use Cygnus\OlyticsBundle\Model\Event\EventInterface;
+
+interface HookInterface
+{
+    /**
+     * Executes the Event modification hook
+     *
+     * @param  Cygnus\OlyticsBundle\Model\Event\EventInterface  $event
+     * @param  string                                           $accountKey
+     * @param  string                                           $groupKey
+     * @return Cygnus\OlyticsBundle\Model\Event\EventInterface
+     */
+    public function execute(EventInterface $event, $accountKey, $groupKey);
+
+    /**
+     * Determines if this hook supports the provided event, account, and group
+     *
+     * @param  Cygnus\OlyticsBundle\Model\Event\EventInterface  $event
+     * @param  string                                           $accountKey
+     * @param  string                                           $groupKey
+     * @return bool
+     */
+    public function supports(EventInterface $event, $accountKey, $groupKey);
+}

--- a/src/Cygnus/OlyticsBundle/EventHook/Manager.php
+++ b/src/Cygnus/OlyticsBundle/EventHook/Manager.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Cygnus\OlyticsBundle\EventHook;
+
+use Cygnus\OlyticsBundle\Model\Event\EventInterface;
+
+class Manager
+{
+    /**
+     * Contains all registered Event modification hooks
+     *
+     * @return array<Cygnus\OlyticsBundle\EventHook\HookInterface>
+     */
+    protected $eventHooks = [];
+
+    /**
+     * Adds a registered Event modification hook
+     *
+     * @param  Cygnus\OlyticsBundle\EventHook\HookInterface  $eventHook
+     * @return self
+     */
+    public function addEventHook(HookInterface $eventHook)
+    {
+        $this->eventHooks[get_class($eventHook)] = $eventHook;
+        return $this;
+    }
+
+    /**
+     * Gets all registered Event modification hooks
+     *
+     * @return array<Cygnus\OlyticsBundle\EventHook\HookInterface>
+     */
+    public function getEventHooks()
+    {
+        return $this->eventHooks;
+    }
+
+    /**
+     * Executes all registered Event modification hooks
+     *
+     * @param  Cygnus\OlyticsBundle\Model\Event\EventInterface  $event
+     * @param  string                                           $accountKey
+     * @param  string                                           $groupKey
+     * @return self
+     */
+    public function executeAll(EventInterface $event, $accountKey, $groupKey)
+    {
+        foreach ($this->getEventHooks() as $eventHook) {
+            $event = $eventHook->execute($event, $accountKey, $groupKey);
+        }
+        return $event;
+    }
+}

--- a/src/Cygnus/OlyticsBundle/EventHook/MongoUserIdHook.php
+++ b/src/Cygnus/OlyticsBundle/EventHook/MongoUserIdHook.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Cygnus\OlyticsBundle\EventHook;
+
+use Doctrine\MongoDB\Connection;
+use Doctrine\MongoDB\Query\Builder;
+use Cygnus\OlyticsBundle\Model\Event\EventInterface;
+
+class MongoUserIdHook implements HookInterface
+{
+    /**
+     * The MongoDB connection that contains the user collection for retrieving Mongo user ids
+     *
+     * @var Doctrine\MongoDB\Connection
+     */
+    protected $userConnection;
+
+    /**
+     * The cache client for retrieving Mongo user ids based on Omeda encypted ids
+     *
+     * @var Snc\RedisBundle\Client\Phpredis\Client
+     */
+    protected $cacheClient;
+
+    /**
+     * Executes the Event modification hook
+     *
+     * @param  Cygnus\OlyticsBundle\Model\Event\EventInterface  $event
+     * @param  string                                           $accountKey
+     * @param  string                                           $groupKey
+     * @return Cygnus\OlyticsBundle\Model\Event\EventInterface
+     */
+    public function execute(EventInterface $event, $accountKey, $groupKey)
+    {
+        if (!$this->supports($event, $accountKey, $groupKey)) {
+            return $event;
+        }
+
+        $customerId = $event->getSession()->getCustomerId();
+        if (null === $customerId) {
+            // Anonymous
+            return $event;
+        }
+
+        if ($customerId instanceof \MongoId) {
+            // Customer ID is already a MongoId
+            return $event;
+        }
+
+        if (!is_string($customerId)) {
+            // Unknown identifier. Set null
+            $event->getSession()->setCustomerId(null);
+            return $event;
+        }
+
+        if (24 === strlen($customerId)) {
+            // Mongo string id
+            return $this->setCustomerIdFromMongoString($event, $customerId);
+        }
+
+        if (15 === strlen($customerId)) {
+            // Omeda encrypted customer id
+            return $this-> setCustomerIdFromOmedaId($event, $customerId, $accountKey, $groupKey);
+        }
+
+        // Unknown or invalid. Set null
+        $event->getSession()->setCustomerId(null);
+        return $event;
+    }
+
+    /**
+     * Sets the customer id from a Mongo id string
+     *
+     * @param  Cygnus\OlyticsBundle\Model\Event\EventInterface  $event
+     * @param  string                                           $customerId
+     * @return Cygnus\OlyticsBundle\Model\Event\EventInterface
+     */
+    protected function setCustomerIdFromMongoString(EventInterface $event, $customerId)
+    {
+        try {
+            $mongoId = new \MongoId($customerId);
+            $event->getSession()->setCustomerId($mongoId);
+        } catch (\Exception $e) {
+            $event->getSession()->setCustomerId(null);
+        }
+        return $event;
+    }
+
+    /**
+     * Sets the customer id from an Omeda encrypted id
+     *
+     * @param  Cygnus\OlyticsBundle\Model\Event\EventInterface  $event
+     * @param  string                                           $customerId
+     * @param  string                                           $accountKey
+     * @param  string                                           $groupKey
+     * @return Cygnus\OlyticsBundle\Model\Event\EventInterface
+     */
+    protected function setCustomerIdFromOmedaId(EventInterface $event, $customerId, $accountKey, $groupKey)
+    {
+        $cacheKey = $this->getCacheKey($customerId, $accountKey, $groupKey);
+
+        $cacheResult = $this->getCacheClient()->get($cacheKey);
+
+        if (false === $cacheResult) {
+            // Not found in cache. Retrieve from DB
+
+            $builder = new Builder($this->getUserCollection());
+
+            $cursor = $builder
+                ->find()
+                ->field('site')->equals($this->getWebsiteHost($groupKey))
+                ->field('omeda_encrypted_id')->equals($customerId)
+                ->select('_id', 'omeda_encrypted_id')
+                ->getQuery()
+                ->execute()
+            ;
+
+            $result = $cursor->getNext();
+
+            $id = (is_array($result) && isset($result['_id'])) ? $result['_id'] : null;
+
+            // Set to cache
+            $this->getCacheClient()->setex($cacheKey, 60*60*24*7, serialize($id));
+            $event->getSession()->setCustomerId($id);
+            return $event;
+        }
+
+        $id = unserialize($cacheResult);
+        $event->getSession()->setCustomerId($id);
+        return $event;
+    }
+
+    /**
+     * Gets the cache key for an Omeda encrypted id
+     *
+     * @param  string   $customerId
+     * @param  string   $accountKey
+     * @param  string   $groupKey
+     * @return string
+     */
+    protected function getCacheKey($customerId, $accountKey, $groupKey)
+    {
+        return sprintf('Olytics:MongoUserIdHook:%s:%s:%s', $accountKey, $groupKey, $customerId);
+    }
+
+    /**
+     * Sets the cache client
+     *
+     * @param  Snc\RedisBundle\Client\Phpredis\Client $cacheClient
+     * @return self
+     */
+    public function setCacheClient($cacheClient)
+    {
+        $this->cacheClient = $cacheClient;
+        return $this;
+    }
+
+    /**
+     * Gets the cache client
+     *
+     * @return Snc\RedisBundle\Client\Phpredis\Client $cacheClient
+     */
+    public function getCacheClient()
+    {
+        return $this->cacheClient;
+    }
+
+    /**
+     * Gets the user collection for retrieving Mongo user ids
+     *
+     * @return Doctrine\MongoDB\Collection
+     */
+    protected function getUserCollection()
+    {
+        return $this->getUserConnection()->selectCollection('merrick', 'users_v2');
+    }
+
+    /**
+     * Sets The MongoDB connection that contains the user collection
+     *
+     * @param  Doctrine\MongoDB\Connection $connection
+     * @return self
+     */
+    public function setUserConnection(Connection $connection)
+    {
+        $this->userConnection = $connection;
+        return $this;
+    }
+
+    /**
+     * Gets The MongoDB connection that contains the user collection
+     *
+     * @return Doctrine\MongoDB\Connection $connection
+     */
+    public function getUserConnection()
+    {
+        return $this->userConnection;
+    }
+
+    /**
+     * Gets the website host by group key
+     *
+     * @todo   This should be configured at the Olytics application level
+     * @param  string $groupKey
+     * @return string|null
+     */
+    protected function getWebsiteHost($groupKey)
+    {
+        if (!isset($this->getWebsiteHosts()[$groupKey])) {
+            return null;
+        }
+        return $this->getWebsiteHosts()[$groupKey];
+    }
+
+    /**
+     * Returns the website hosts by group key
+     *
+     * @todo   This should be configured at the Olytics application level
+     * @return array
+     */
+    protected function getWebsiteHosts()
+    {
+        return [
+            'cavc'  => 'www.aviationpros.com',
+            'll'    => 'www.locksmithledger.com',
+            'ofcr'  => 'www.officer.com',
+            'vspc'  => 'www.vehicleservicepros.com',
+            'sdce'  => 'www.sdcexec.com',
+            'fl'    => 'www.foodlogistics.com',
+            'mass'  => 'www.masstransitmag.com',
+            'gip'   => 'www.greenindustrypros.com',
+            'mprc'  => 'www.myprintresource.com',
+            'fcp'   => 'www.forconstructionpros.com',
+            'ooh'   => 'www.oemoffhighway.com',
+            'frpc'  => 'www.forresidentialpros.com',
+            'csn'   => 'www.cpapracticeadvisor.com',
+            'vmw'   => 'www.vendingmarketwatch.com',
+            'emsr'  => 'www.emsworld.com',
+            'fhc'   => 'www.firehouse.com',
+            'siw'   => 'www.securityinfowatch.com',
+        ];
+    }
+
+    /**
+     * Determines if this hook supports the provided event, account, and group
+     *
+     * @param  Cygnus\OlyticsBundle\Model\Event\EventInterface  $event
+     * @param  string                                           $accountKey
+     * @param  string                                           $groupKey
+     * @return bool
+     */
+    public function supports(EventInterface $event, $accountKey, $groupKey)
+    {
+        if (in_array($accountKey, ['cygnus', 'acbm']) && null !== $this->getWebsiteHost($groupKey)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Cygnus/OlyticsBundle/Resources/config/services.yml
+++ b/src/Cygnus/OlyticsBundle/Resources/config/services.yml
@@ -9,6 +9,8 @@ parameters:
     cygnus_olytics.aggregation.openx.class: Cygnus\OlyticsBundle\Aggregation\OpenXImpressionAggregation
     cygnus_olytics.aggregation.openx.user.class: Cygnus\OlyticsBundle\Aggregation\OpenXUserAggregation
     cygnus_olytics.aggregation.archive.content.class: Cygnus\OlyticsBundle\Aggregation\ContentArchiveAggregation
+    cygnus_olytics.event_hook_manager.class: Cygnus\OlyticsBundle\EventHook\Manager
+    cygnus_olytics.event_hook.mongo_user_id.class: Cygnus\OlyticsBundle\EventHook\MongoUserIdHook
 
 services:
     cygnus_olytics.bot_detector:
@@ -24,6 +26,7 @@ services:
             - @doctrine_mongodb.odm.olytics_connection
             - @cygnus_olytics.index_manager
             - @cygnus_olytics.aggregation_manager
+            - @cygnus_olytics.event_hook_manager
             - %cygnus_olytics.accounts%
 
     cygnus_olytics.events.website.request_factory:
@@ -62,4 +65,15 @@ services:
         class: %cygnus_olytics.aggregation.archive.content.class%
         tags:
             - { name: cygnus_olytics.aggregation }
+
+    cygnus_olytics.event_hook_manager:
+        class: %cygnus_olytics.event_hook_manager.class%
+
+    cygnus_olytics.event_hook.mongo_user_id:
+        class: %cygnus_olytics.event_hook.mongo_user_id.class%
+        calls:
+            - [ setUserConnection, [ @doctrine_mongodb.odm.merrick_connection ] ]
+            - [ setCacheClient, [ @snc_redis.cache ] ]
+        tags:
+            - { name: cygnus_olytics.event_hook }
 


### PR DESCRIPTION
This allows the modification of an Event object before it is persisted to the database. Hooks can be enabled/disabled based on account/group (and other parameters) and adjust the values of the event before insertion. 

The specific hook added in this PR is enabled for ACMB and Cygnus groups, and ensures that all incoming customer ids are set as MongoIds. This was needed because Olytics customer cookies still exist with legacy data, such as Omeda encrypted customer ids and string Merrick user ids. This hook converts these values (where possible) into ObjectId() format.
