### PR TITLE
Added Unload Tracking

### DIFF
--- a/src/Cygnus/OlyticsBundle/Resources/public/js/sapience.js
+++ b/src/Cygnus/OlyticsBundle/Resources/public/js/sapience.js
@@ -296,6 +296,37 @@ var Sapience = (function() {
         }
     }
 
+    function UnloadTracker()
+    {
+        var bound = [];
+
+        init();
+
+        this.bind = function(entity) {
+            Debugger.info('UnloadTracker()', 'Bound entity to window unload.', entity);
+            bound.push(entity);
+            return this;
+        }
+
+        function init()
+        {
+            window.addEventListener("unload", function (e) {
+                sendEvents();
+                // e.returnValue = null;
+                // event.preventDefault();
+
+                // e.preventDefault();
+            });
+        }
+
+        function sendEvents()
+        {
+            for (var i in bound) {
+                _sapient.push(['_trackEvent', 'unload', bound[i]]);
+            }
+        }
+    }
+
     /**
      *
      */
@@ -311,7 +342,8 @@ var Sapience = (function() {
             },
             previousEvents = {},
             visitor, session, identity, campaign,
-            focus, ping, scroll
+            focus, ping, scroll, unload,
+            specialActions = ['scroll', 'focus', 'unload']
         ;
 
         function init()
@@ -334,6 +366,23 @@ var Sapience = (function() {
             logEvent(new Event(action, entity, relatedTo, data));
         }
 
+        function trackAlso(actions, entity)
+        {
+            if (Utils.isString(actions)) {
+                actions = [actions];
+            } else if (!Utils.isArray(actions)) {
+                Debugger.error('Tracker()', 'Unable to assign additional actions to track. Actions must be an array or string.');
+                return;
+            }
+
+            for (var i in specialActions) {
+                if (0 <= actions.indexOf(specialActions[i])) {
+                    var method = '_track' + specialActions[i].toLowerCase().charAt(0).toUpperCase() + specialActions[i].slice(1);
+                    Tracker[method](entity);
+                }
+            }
+        }
+
         function trackScroll(entity)
         {
             if (!Utils.isDefined(scroll)) {
@@ -354,6 +403,17 @@ var Sapience = (function() {
                 entity = getPageViewEntity();
             }
             focus.bind(entity);
+        }
+
+        function trackUnload(entity)
+        {
+            if (!Utils.isDefined(unload)) {
+                unload = new UnloadTracker();
+            }
+            if (!Utils.isDefined(entity)) {
+                entity = getPageViewEntity();
+            }
+            unload.bind(entity);
         }
 
         function resendLastEvent(action)
@@ -1024,6 +1084,10 @@ var Sapience = (function() {
                 trackEvent(action, entity, relatedTo, data);
                 return this;
             },
+            _trackAlso: function (actions, entity) {
+                trackAlso(actions, entity);
+                return this;
+            },
             _trackPageview: function() {
                 trackPageview();
                 return this;
@@ -1034,6 +1098,10 @@ var Sapience = (function() {
             },
             _trackFocus: function (entity) {
                 trackFocus(entity);
+                return this;
+            },
+            _trackUnload: function (entity) {
+                trackUnload(entity);
                 return this;
             },
             _resendLastEvent: function(action) {

--- a/src/Cygnus/OlyticsBundle/Resources/views/Default/sapience.html.twig
+++ b/src/Cygnus/OlyticsBundle/Resources/views/Default/sapience.html.twig
@@ -41,10 +41,7 @@
              var sampleEntity = {type: 'content', clientId: 1234};
 
              _sapient.push(['_trackEvent', 'view', sampleEntity]);
-             _sapient.push(['_trackScroll', sampleEntity]);
-             _sapient.push(['_trackFocus', sampleEntity]);
-
-             _sapient.push(['_trackPageview']);
+             _sapient.push(['_trackAlso', ['scroll', 'focus', 'unload'], sampleEntity]);
 
         </script>
 
@@ -82,3 +79,5 @@
     </body>
 
 </html>
+
+


### PR DESCRIPTION
Entities can now be bound to unload tracking. This will fire an event when the browser window (or tab) is closed.

A `_trackAlso` helper function was created. This allows you to bind focus, scroll, and/or unload events to an entity in one call (as opposed to having to call `_trackFocus`, `_trackScroll`, etc individually). You can now call `_sapient.push(['_trackAlso', ['scroll','focus','unload'], var someEntity]);`

Finally, tweaked the `getCampaign` function to check the existence of a cookie before checking for a configured campaign. This changes to search order to Query String -> Cookie -> Configured Campaign.
