### PR TITLE
Move GIP to ACBM

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -55,11 +55,11 @@ cygnus_olytics:
     host: olytics.cygnus.com
     accounts:
         acbm:
-            products: [fcp, ooh, sdce, fl]
+            products: [fcp, ooh, sdce, fl, gip]
         as3:
             products: [clarity]
         cygnus:
-            products: [vmw, cavc, csn, emsr, fhc, frpc, gip, ll, mass, mprc, ofcr, siw, vspc, 'siw-brevity']
+            products: [vmw, cavc, csn, emsr, fhc, frpc, ll, mass, mprc, ofcr, siw, vspc, 'siw-brevity']
         indm:
             products: [ien]
         scomm:


### PR DESCRIPTION
Changes GIP from Cygnus account to ACBM.

---

- [x] **PRE-MERGE** Add DNS, apache config acbm-gip.baseplatform.io
- [ ] **PRE-MERGE** Copy cygnus:gip databases
```
db.copyDatabase('oly_cygnus_gip', 'oly_acbm_gip')
db.copyDatabase('oly_cygnus_gip_brevity_events', 'oly_acbm_gip_brevity_events')
db.copyDatabase('oly_cygnus_gip_events', 'oly_acbm_gip_events')
db.copyDatabase('oly_cygnus_gip_website_events', 'oly_acbm_gip_website_events')
```
- [ ] Merge
  - [ ] Also merge cygnusb2b/merrick#299
  - [ ] Also merge cygnusb2b/base-platform#28000 GIP change
- [ ] **POST-MERGE** Cleanup
  - [ ] Remove cygnus:gip databases
```
use oly_cygnus_gip
db.dropDatabase();
use oly_cygnus_gip_brevity_events
db.dropDatabase();
use oly_cygnus_gip_events
db.dropDatabase();
use oly_cygnus_gip_website_events
db.dropDatabase();
```
  - [ ] Remove DNS, apache config cygnus-gip.baseplatform.io