### PR TITLE
Set timeouts for Mongo

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -19,4 +19,3 @@ cygnus_olytics:
             journal: false
             w: 1
             connectTimeoutMS: 200
-            maxTimeMS: 10000


### PR DESCRIPTION
![screen shot 2017-10-09 at 2 46 17 pm](https://user-images.githubusercontent.com/3812216/31355613-ac1f69d4-ad00-11e7-8f0e-b9dcf9af600a.png)


We had an issue where the master mongo server failed causing random long load times. The issue was that we don't have connectTimeoutMS set low enough so it waits 30s. So I changed that to be the same as Platform.
